### PR TITLE
Update HasData.php

### DIFF
--- a/src/Traits/HasData.php
+++ b/src/Traits/HasData.php
@@ -8,7 +8,10 @@ trait HasData
 {
     public function getLocale(): string
     {
-        return app()->getLocale();
+        $locale = app()->getLocale();
+        $localePrefix = explode('_', $locale)[0]; // Pega apenas a parte inicial do locale
+
+        return $localePrefix;
     }
 
     public function getCountriesList(): array
@@ -18,6 +21,19 @@ trait HasData
 
     public function getList(): array
     {
-        return require __DIR__ . '/../data/' . $this->getLocale() . '/country.php';
+
+        $customPath = resource_path('custom/vendor/parfaitementweb/filament-country-field/src/data/' . $this->getLocale() . '/country.php');
+        $defaultPath = __DIR__ . '/../data/' . $this->getLocale() . '/country.php';
+
+        if (file_exists($customPath)) {
+            return require $customPath;
+        }
+
+        if  (file_exists($defaultPath)) {
+            return require $defaultPath;
+        } else {
+            return require __DIR__ . '/../data/en/country.php';
+        }
+
     }
 }


### PR DESCRIPTION
- Fixed the issue when loading translation files for locales with subdefinitions, such as `pt_BR`.
- Added a fallback to the default 'en' locale if no translation is found for the specified locale.